### PR TITLE
use pull_request_target and not pull_request for the safe workflows

### DIFF
--- a/.github/workflows/add-new-issues-and-pull-requests-to-origami-project-board.yml
+++ b/.github/workflows/add-new-issues-and-pull-requests-to-origami-project-board.yml
@@ -2,7 +2,6 @@ name: Add new issues and pull requests to Origami Project Board
 on:
   - issues
   - pull_request_target
-  - pull_request
 
 jobs:
   origami_project_board_job:

--- a/.github/workflows/apply-labels.yml
+++ b/.github/workflows/apply-labels.yml
@@ -2,7 +2,6 @@ name: Apply Origami labels
 on:
   - issues
   - pull_request_target
-  - pull_request
 jobs:
   apply-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,6 +1,6 @@
 name: Auto Approve Dependabot PRs
 
-on: pull_request
+on: pull_request_target
 
 jobs:
   auto-update-dependabot:

--- a/.github/workflows/sync-repo-labels.yml
+++ b/.github/workflows/sync-repo-labels.yml
@@ -2,7 +2,6 @@ name: Sync Origami labels
 on:
   - issues
   - pull_request_target
-  - pull_request
 jobs:
   sync-labels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We have workflows that currently fail to run correctly for pull-requests from forks or pull-requests from dependabot. The reason is because those workflows are being triggered by the 'pull_request' event, which does will use a restricted github api token for pull-requests from forks or dependabot for security reasons.

For our workflows which are 'safe' (meaning they do not checkout the code or execute the code in the repository), we can change their trigger from 'pull_request' to 'pull_request_target', which uses a github api token with more permissions, specifically it has permission to read/use secrets, which are the things are workflows require.

Our workflows are safe, they do not checkout or execute the code from the repository, so we should change to using `pull_request_target` to make our workflows work for dependabot and pull-requests from forks.